### PR TITLE
Fix @since placeholder spacing missed by the release workflow

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -26,7 +26,7 @@ jobs:
           if [[ -s "/tmp/changelog_output" ]]; then cat /tmp/changelog_output; else echo "Please make sure the CHANGELOG.md is updated: couldn't find the changes for '${{ github.event.inputs.tag }}'."; exit 1; fi
 
       - name: Search for the version tag and replace it
-        run: grep -Rin "@since {VERSION}" --exclude-dir=vendor --exclude-dir=assets --exclude-dir=.github --exclude-dir=.git | while read -r file; do filename=$(echo "$file" | cut -d ':' -f1); if echo "$filename" | egrep -qv ".(js|php)$"; then continue; fi; sed -i "s/@since {VERSION}$/@since ${{ github.event.inputs.tag }}/g" $filename; done
+        run: grep -RinE "@since +\{VERSION\}" --exclude-dir=vendor --exclude-dir=assets --exclude-dir=.github --exclude-dir=.git | while read -r file; do filename=$(echo "$file" | cut -d ':' -f1); if echo "$filename" | egrep -qv ".(js|php)$"; then continue; fi; sed -i -E "s/@since +\{VERSION\}$/@since ${{ github.event.inputs.tag }}/g" $filename; done
 
       - name: Update constants
         run: |

--- a/src/Admin/AJAX.php
+++ b/src/Admin/AJAX.php
@@ -5,7 +5,7 @@
  * Handles AJAX requests for the admin interface.
  *
  * @package wp-healthcheck
- * @since   {VERSION}
+ * @since {VERSION}
  */
 
 namespace THSCD\WPHC\Admin;

--- a/src/Admin/Dashboard.php
+++ b/src/Admin/Dashboard.php
@@ -5,7 +5,7 @@
  * Handles the dashboard page registration and rendering.
  *
  * @package wp-healthcheck
- * @since   {VERSION}
+ * @since {VERSION}
  */
 
 namespace THSCD\WPHC\Admin;

--- a/src/Admin/Metaboxes.php
+++ b/src/Admin/Metaboxes.php
@@ -5,7 +5,7 @@
  * Handles the registration and rendering of meta boxes.
  *
  * @package wp-healthcheck
- * @since   {VERSION}
+ * @since {VERSION}
  */
 
 namespace THSCD\WPHC\Admin;

--- a/src/Admin/Notices.php
+++ b/src/Admin/Notices.php
@@ -5,7 +5,7 @@
  * Handles displaying system notices in the admin interface.
  *
  * @package wp-healthcheck
- * @since   {VERSION}
+ * @since {VERSION}
  */
 
 namespace THSCD\WPHC\Admin;

--- a/src/Admin/Pointers.php
+++ b/src/Admin/Pointers.php
@@ -5,7 +5,7 @@
  * Handles WordPress admin pointers for help tooltips.
  *
  * @package wp-healthcheck
- * @since   {VERSION}
+ * @since {VERSION}
  */
 
 namespace THSCD\WPHC\Admin;

--- a/src/Modules/Plugins.php
+++ b/src/Modules/Plugins.php
@@ -5,7 +5,7 @@
  * Handles plugin-related checks and monitoring.
  *
  * @package wp-healthcheck
- * @since   {VERSION}
+ * @since {VERSION}
  */
 
 namespace THSCD\WPHC\Modules;

--- a/src/Utils/View.php
+++ b/src/Utils/View.php
@@ -5,7 +5,7 @@
  * Handles loading and rendering of view files.
  *
  * @package wp-healthcheck
- * @since   {VERSION}
+ * @since {VERSION}
  */
 
 namespace THSCD\WPHC\Utils;


### PR DESCRIPTION
## What's changed

- Normalizes the file-level `@since {VERSION}` docblocks to a single space.
- Hardens the `build_and_release` workflow's version-replacement to match `@since +{VERSION}` (one or more spaces), so docblock alignment can't cause a missed `{VERSION}` replacement at release time.
